### PR TITLE
feat: Copy Update Command

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,4 +2,11 @@
 
 import { tanstackConfig } from '@tanstack/eslint-config'
 
-export default [...tanstackConfig]
+export default [
+  ...tanstackConfig,
+  {
+    rules: {
+      'sort-imports': 'off',
+    },
+  },
+]

--- a/src/components/update-command.tsx
+++ b/src/components/update-command.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { Check, Copy, Terminal } from 'lucide-react'
+import type { PackageManager } from '@/lib/package-managers'
+import { PACKAGE_MANAGERS, buildUpdateCommand } from '@/lib/package-managers'
+import { cn } from '@/lib/utils'
+
+export function UpdateCommand({
+  dependencies,
+  devDependencies,
+}: {
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
+}) {
+  const [manager, setManager] = useState<PackageManager>('pnpm')
+  const [copied, setCopied] = useState(false)
+
+  const hasPackages =
+    Object.keys(dependencies).length > 0 ||
+    Object.keys(devDependencies).length > 0
+
+  if (!hasPackages) return null
+
+  const command = buildUpdateCommand(manager, dependencies, devDependencies)
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable in some environments
+    }
+  }
+
+  return (
+    <div className="border-4 border-black mb-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-hidden bg-zinc-950 text-zinc-100">
+      <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
+        <Terminal className="size-3.5 shrink-0 text-zinc-500" aria-hidden />
+
+        <div
+          className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+          role="tablist"
+          aria-label="Package manager"
+        >
+          {PACKAGE_MANAGERS.map((pm) => (
+            <button
+              key={pm}
+              type="button"
+              role="tab"
+              aria-selected={manager === pm}
+              onClick={() => setManager(pm)}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+                manager === pm
+                  ? 'bg-zinc-800 text-zinc-50'
+                  : 'text-zinc-400 hover:text-zinc-200',
+              )}
+            >
+              {pm}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="shrink-0 rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+          aria-label={copied ? 'Copied' : 'Copy command'}
+        >
+          {copied ? (
+            <Check className="size-3.5" aria-hidden />
+          ) : (
+            <Copy className="size-3.5" aria-hidden />
+          )}
+        </button>
+      </div>
+
+      <pre className="overflow-x-auto p-4 text-sm leading-relaxed">
+        <code className="font-mono text-zinc-100 whitespace-pre-wrap break-all">
+          {command}
+        </code>
+      </pre>
+    </div>
+  )
+}

--- a/src/components/update-command.tsx
+++ b/src/components/update-command.tsx
@@ -14,13 +14,9 @@ export function UpdateCommand({
   const [manager, setManager] = useState<PackageManager>('pnpm')
   const [copied, setCopied] = useState(false)
 
-  const hasPackages =
-    Object.keys(dependencies).length > 0 ||
-    Object.keys(devDependencies).length > 0
-
-  if (!hasPackages) return null
-
   const command = buildUpdateCommand(manager, dependencies, devDependencies)
+
+  if (!command) return null
 
   async function handleCopy() {
     try {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,8 @@ export const getNextNpmData = async (): Promise<{
 export const getOpenNextVersion = async (): Promise<{
   versionNumber: number
   version: string
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
   error?: string
 }> => {
   try {
@@ -75,12 +77,16 @@ export const getOpenNextVersion = async (): Promise<{
     return {
       versionNumber: major(validatedVersion),
       version: validatedVersion,
+      dependencies: parsed.dependencies,
+      devDependencies: parsed.devDependencies,
     }
   } catch (error) {
     console.error('Error fetching OpenNextJS version:', error)
     return {
       versionNumber: 0,
       version: 'error',
+      dependencies: {},
+      devDependencies: {},
       error:
         error instanceof z.ZodError
           ? error.issues.map((issue) => issue.message).join(', ')

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -1,0 +1,49 @@
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+
+export const PACKAGE_MANAGERS: Array<PackageManager> = [
+  'pnpm',
+  'npm',
+  'yarn',
+  'bun',
+]
+
+function toSpecs(packages: Record<string, string>): Array<string> {
+  return Object.entries(packages).map(([name, version]) => `${name}@${version}`)
+}
+
+export function buildUpdateCommand(
+  manager: PackageManager,
+  dependencies: Record<string, string>,
+  devDependencies: Record<string, string>,
+): string {
+  const deps = toSpecs(dependencies)
+  const devDeps = toSpecs(devDependencies)
+
+  const depCmd = (() => {
+    switch (manager) {
+      case 'pnpm':
+        return deps.length ? `pnpm add ${deps.join(' ')}` : ''
+      case 'npm':
+        return deps.length ? `npm install ${deps.join(' ')}` : ''
+      case 'yarn':
+        return deps.length ? `yarn add ${deps.join(' ')}` : ''
+      case 'bun':
+        return deps.length ? `bun add ${deps.join(' ')}` : ''
+    }
+  })()
+
+  const devCmd = (() => {
+    switch (manager) {
+      case 'pnpm':
+        return devDeps.length ? `pnpm add -D ${devDeps.join(' ')}` : ''
+      case 'npm':
+        return devDeps.length ? `npm install -D ${devDeps.join(' ')}` : ''
+      case 'yarn':
+        return devDeps.length ? `yarn add -D ${devDeps.join(' ')}` : ''
+      case 'bun':
+        return devDeps.length ? `bun add -d ${devDeps.join(' ')}` : ''
+    }
+  })()
+
+  return [depCmd, devCmd].filter(Boolean).join(' && ')
+}

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -7,6 +7,29 @@ export const PACKAGE_MANAGERS: Array<PackageManager> = [
   'bun',
 ]
 
+/** Runtime packages we surface for upgrade commands. */
+const RUNTIME_PACKAGES = [
+  '@opennextjs/cloudflare',
+  'next',
+  'react',
+  'react-dom',
+] as const
+
+/** Matching type packages only — skip tooling like tailwind/eslint/wrangler. */
+const TYPE_PACKAGES = ['@types/react', '@types/react-dom'] as const
+
+function pickPackages(
+  source: Record<string, string>,
+  names: ReadonlyArray<string>,
+): Record<string, string> {
+  const picked: Record<string, string> = {}
+  for (const name of names) {
+    const version = source[name]
+    if (version) picked[name] = version
+  }
+  return picked
+}
+
 function toSpecs(packages: Record<string, string>): Array<string> {
   return Object.entries(packages).map(([name, version]) => `${name}@${version}`)
 }
@@ -16,8 +39,8 @@ export function buildUpdateCommand(
   dependencies: Record<string, string>,
   devDependencies: Record<string, string>,
 ): string {
-  const deps = toSpecs(dependencies)
-  const devDeps = toSpecs(devDependencies)
+  const deps = toSpecs(pickPackages(dependencies, RUNTIME_PACKAGES))
+  const devDeps = toSpecs(pickPackages(devDependencies, TYPE_PACKAGES))
 
   const depCmd = (() => {
     switch (manager) {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -2,9 +2,12 @@ import { z } from 'zod'
 import { major, valid } from 'semver'
 
 export const packageJsonSchema = z.object({
-  dependencies: z.object({
-    next: z.string().min(1, 'Version string cannot be empty'),
-  }),
+  dependencies: z
+    .record(z.string(), z.string())
+    .refine((deps) => typeof deps.next === 'string' && deps.next.length > 0, {
+      message: 'dependencies.next is required',
+    }),
+  devDependencies: z.record(z.string(), z.string()).optional().default({}),
 })
 
 // Schema for version string (e.g., "15.0.0", "16.1.2")

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -8,6 +8,8 @@ export const generateHomePageMeta = (data: LoaderData | undefined) => {
     latestNextVersion: 'unknown',
     latestNextMajorVersion: 0,
     vercelVersionHistory: [],
+    dependencies: {},
+    devDependencies: {},
   }
 
   const { version, latestNextVersion, versionNumber, latestNextMajorVersion } =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,5 +10,7 @@ export interface LoaderData {
   latestNextVersion: string
   latestNextMajorVersion: number
   vercelVersionHistory: Array<string>
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
   error?: string
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { gte } from 'semver'
 import type { LoaderData } from '@/lib/types'
 import { getNextNpmData, getOpenNextVersion } from '@/lib/api'
 import { generateHomePageMeta } from '@/lib/seo'
+import { UpdateCommand } from '@/components/update-command'
 
 export const Route = createFileRoute('/')({
   // Both fetches run in parallel — one GitHub call, one npm call
@@ -31,6 +32,8 @@ export const Route = createFileRoute('/')({
         latestNextVersion: 'error',
         latestNextMajorVersion: 0,
         vercelVersionHistory: [],
+        dependencies: {},
+        devDependencies: {},
         error: error instanceof Error ? error.message : 'Unknown error',
       }
     }
@@ -92,10 +95,19 @@ function PageSkeleton() {
           ))}
         </div>
 
-        {/* Match status card skeleton */}
-        <div className="border-4 border-black p-5 mb-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] bg-gray-100 text-center space-y-2">
-          <SkeletonBlock className="h-2 w-24 mx-auto" />
-          <SkeletonBlock className="h-8 w-32 mx-auto" />
+        {/* Update command skeleton */}
+        <div className="border-4 border-black mb-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] overflow-hidden bg-zinc-950">
+          <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
+            <SkeletonBlock className="h-3.5 w-3.5 bg-zinc-700" />
+            <SkeletonBlock className="h-6 w-12 bg-zinc-700" />
+            <SkeletonBlock className="h-6 w-10 bg-zinc-800" />
+            <SkeletonBlock className="h-6 w-10 bg-zinc-800" />
+            <SkeletonBlock className="h-6 w-10 bg-zinc-800" />
+          </div>
+          <div className="p-4 space-y-2">
+            <SkeletonBlock className="h-4 w-full bg-zinc-800" />
+            <SkeletonBlock className="h-4 w-3/4 bg-zinc-800" />
+          </div>
         </div>
 
         <div className="text-center">
@@ -251,24 +263,15 @@ function VersionHistoryList({
 
 function App() {
   const {
-    versionNumber,
     version,
     latestNextVersion,
-    latestNextMajorVersion,
     vercelVersionHistory,
+    dependencies,
+    devDependencies,
     error,
   } = Route.useLoaderData()
 
   const exactMatch = version === latestNextVersion
-  const majorMatch = versionNumber === latestNextMajorVersion
-
-  const statusBg = exactMatch
-    ? 'bg-green-300'
-    : majorMatch
-      ? 'bg-orange-300'
-      : 'bg-red-300'
-
-  const statusLabel = exactMatch ? 'Exact match' : majorMatch ? 'Close' : 'Behind'
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4 bg-white">
@@ -312,15 +315,10 @@ function App() {
           />
         )}
 
-        {/* Match Status */}
-        <div
-          className={`border-4 border-black p-5 mb-8 shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] text-center ${statusBg}`}
-        >
-          <p className="text-xs font-black uppercase tracking-widest text-black mb-1">
-            Match Status
-          </p>
-          <p className="text-3xl font-black text-black">{statusLabel}</p>
-        </div>
+        <UpdateCommand
+          dependencies={dependencies}
+          devDependencies={devDependencies}
+        />
 
         {/* Footer */}
         <div className="text-center">


### PR DESCRIPTION
## Summary

Replaced the Match Status block with a package-manager terminal (pnpm/npm/yarn/bun + copy) that builds update commands from OpenNext’s live `dependencies` and `devDependencies`.